### PR TITLE
Add pandas and polars as dependencies in pyproject.toml

### DIFF
--- a/dataframe_api_compat/__init__.py
+++ b/dataframe_api_compat/__init__.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
-from dataframe_api_compat import pandas_standard
-from dataframe_api_compat import polars_standard
+import contextlib
+
+with contextlib.suppress(ModuleNotFoundError):
+    from dataframe_api_compat import pandas_standard
+
+with contextlib.suppress(ModuleNotFoundError):
+    from dataframe_api_compat import polars_standard
+
 
 __all__ = ["pandas_standard", "polars_standard"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,6 @@ authors = [
 description = "Implementation of the DataFrame Standard for pandas and Polars"
 readme = "README.md"
 requires-python = ">=3.8"
-dependencies = [
-  "pandas",
-  "polars"
-]
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ authors = [
 description = "Implementation of the DataFrame Standard for pandas and Polars"
 readme = "README.md"
 requires-python = ">=3.8"
+dependencies = [
+  "pandas",
+  "polars"
+]
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
@MarcoGorelli it looks like the test you added in pandas is being skipped because polars is not installed (and it isn't installed with dateframe-api-compat). Feel free to specify a min version as needed.

https://github.com/pandas-dev/pandas/actions/runs/5811935873/job/15756279828

```
SKIPPED [1] pandas/tests/test_downstream.py:344: could not import 'dataframe_api_compat': No module named 'polars'
```