### PR TITLE
Fix type hint in `convert_to_standard_compliant_column`

### DIFF
--- a/dataframe_api_compat/polars_standard/__init__.py
+++ b/dataframe_api_compat/polars_standard/__init__.py
@@ -244,7 +244,7 @@ def dataframe_from_2d_array(
 
 
 def convert_to_standard_compliant_column(
-    ser: pl.LazyFrame, api_version: str | None = None
+    ser: pl.Series, api_version: str | None = None
 ) -> PolarsDataFrame:
     df = (
         ser.to_frame()


### PR DESCRIPTION
This just broke the Polars CI.

Is there any type checking in this repo? Seems like mypy should alert you here.