### PR TITLE
support more versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,10 +36,25 @@ jobs:
             pytest tests --cov=dataframe_api_compat --cov=tests --cov-fail-under=100
           fi
       - name: install type-checking reqs
-        run: python -m pip install 'git+https://github.com/data-apis/dataframe-api.git#egg=dataframe_api&subdirectory=spec/API_specification' mypy typing-extensions
+        run: |
+          if [ "${{ matrix.python-version }}" = "3.8" ]; then
+            echo "skipping mypy for python 3.8"
+          else
+            python -m pip install 'git+https://github.com/data-apis/dataframe-api.git#egg=dataframe_api&subdirectory=spec/API_specification' mypy typing-extensions
+          fi
       - name: run mypy
-        run: mypy dataframe_api_compat tests
+        run: |
+          if [ "${{ matrix.python-version }}" = "3.8" ]; then
+            echo "skipping mypy for python 3.8"
+          else
+            mypy dataframe_api_compat tests
+          fi
       - name: run polars integration tests
         run: pip uninstall pandas -y && pytest tests/integration/upstream_test.py::TestPolars && pip install -U pandas
       - name: run pandas integration tests
-        run: pip uninstall polars -y && pytest tests/integration/upstream_test.py::TestPandas
+        run: |
+          if [ "${{ matrix.python-version }}" = "3.8" ]; then
+            echo "skipping pandas for python 3.8"
+          else
+            pip uninstall polars -y && pytest tests/integration/upstream_test.py::TestPandas
+          fi

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -30,21 +30,21 @@ jobs:
         run: python -m pip install --upgrade tox virtualenv setuptools pip -r requirements-dev.txt
       - name: Run pytest
         run: |
-          if [ "${{ matrix.python-version }}" = "3.8" ] || [ "${{ matrix.python-version }}" = "3.12" ]; then
+          if ([ "${{ matrix.python-version }}" = "3.8" ] || [ "${{ matrix.python-version }}" = "3.12" ]); then
             pytest tests --cov=dataframe_api_compat --cov=tests --cov-fail-under=50
           else
             pytest tests --cov=dataframe_api_compat --cov=tests --cov-fail-under=100
           fi
       - name: install type-checking reqs
         run: |
-          if [ "${{ matrix.python-version }}" = "3.8" ] || [ "${{ matrix.python-version }}" = "3.12" ]; then
+          if ([ "${{ matrix.python-version }}" = "3.8" ] || [ "${{ matrix.python-version }}" = "3.12" ]); then
             echo "skipping mypy for python 3.8"
           else
             python -m pip install 'git+https://github.com/data-apis/dataframe-api.git#egg=dataframe_api&subdirectory=spec/API_specification' mypy typing-extensions
           fi
       - name: run mypy
         run: |
-          if [ "${{ matrix.python-version }}" = "3.8" ] || [ "${{ matrix.python-version }}" = "3.12" ]; then
+          if ([ "${{ matrix.python-version }}" = "3.8" ] || [ "${{ matrix.python-version }}" = "3.12" ]); then
             echo "skipping mypy for python 3.8"
           else
             mypy dataframe_api_compat tests
@@ -53,7 +53,7 @@ jobs:
         run: pip uninstall pandas -y && pytest tests/integration/upstream_test.py::TestPolars && pip install -U pandas
       - name: run pandas integration tests
         run: |
-          if [ "${{ matrix.python-version }}" = "3.8" ] || [ "${{ matrix.python-version }}" = "3.12" ]; then
+          if ([ "${{ matrix.python-version }}" = "3.8" ] || [ "${{ matrix.python-version }}" = "3.12" ]); then
             echo "skipping pandas for python 3.8"
           else
             pip uninstall polars -y && pytest tests/integration/upstream_test.py::TestPandas

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,7 +9,7 @@ jobs:
   tox:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [windows-latest, ubuntu-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -28,8 +28,12 @@ jobs:
           key: ${{ runner.os }}-build-${{ matrix.python-version }}
       - name: install-reqs
         run: python -m pip install --upgrade tox virtualenv setuptools pip -r requirements-dev.txt
-      - name: run pytest
-        run: pytest tests --cov=dataframe_api_compat --cov=tests --cov-fail-under=100
+      - name: run pytest (3.8 only)
+        if: max.python-version == "3.8"
+        run: pytest tests --cov=dataframe_api_compat --cov=tests
+      - name: run pytest (not 3.8)
+        if: max.python-version != "3.8"
+        run: pytest tests --cov=dataframe_api_compat --cov=tests
       - name: install type-checking reqs
         run: python -m pip install 'git+https://github.com/data-apis/dataframe-api.git#egg=dataframe_api&subdirectory=spec/API_specification' mypy typing-extensions
       - name: run mypy

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -31,9 +31,9 @@ jobs:
       - name: run pytest (3.8 only)
         if: max.python-version == "3.8"
         run: pytest tests --cov=dataframe_api_compat --cov=tests
-      - name: run pytest (not 3.8)
+      - name: run pytest (not 3.8, report coverage)
         if: max.python-version != "3.8"
-        run: pytest tests --cov=dataframe_api_compat --cov=tests
+        run: pytest tests --cov=dataframe_api_compat --cov=tests --cov-fail-under=100
       - name: install type-checking reqs
         run: python -m pip install 'git+https://github.com/data-apis/dataframe-api.git#egg=dataframe_api&subdirectory=spec/API_specification' mypy typing-extensions
       - name: run mypy

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -30,21 +30,21 @@ jobs:
         run: python -m pip install --upgrade tox virtualenv setuptools pip -r requirements-dev.txt
       - name: Run pytest
         run: |
-          if [ "${{ matrix.python-version }}" = "3.8" ]; then
+          if [ "${{ matrix.python-version }}" = "3.8" ] || [ "${{ matrix.python-version }}" = "3.12" ]; then
             pytest tests --cov=dataframe_api_compat --cov=tests --cov-fail-under=50
           else
             pytest tests --cov=dataframe_api_compat --cov=tests --cov-fail-under=100
           fi
       - name: install type-checking reqs
         run: |
-          if [ "${{ matrix.python-version }}" = "3.8" ]; then
+          if [ "${{ matrix.python-version }}" = "3.8" ] || [ "${{ matrix.python-version }}" = "3.12" ]; then
             echo "skipping mypy for python 3.8"
           else
             python -m pip install 'git+https://github.com/data-apis/dataframe-api.git#egg=dataframe_api&subdirectory=spec/API_specification' mypy typing-extensions
           fi
       - name: run mypy
         run: |
-          if [ "${{ matrix.python-version }}" = "3.8" ]; then
+          if [ "${{ matrix.python-version }}" = "3.8" ] || [ "${{ matrix.python-version }}" = "3.12" ]; then
             echo "skipping mypy for python 3.8"
           else
             mypy dataframe_api_compat tests
@@ -53,7 +53,7 @@ jobs:
         run: pip uninstall pandas -y && pytest tests/integration/upstream_test.py::TestPolars && pip install -U pandas
       - name: run pandas integration tests
         run: |
-          if [ "${{ matrix.python-version }}" = "3.8" ]; then
+          if [ "${{ matrix.python-version }}" = "3.8" ] || [ "${{ matrix.python-version }}" = "3.12" ]; then
             echo "skipping pandas for python 3.8"
           else
             pip uninstall polars -y && pytest tests/integration/upstream_test.py::TestPandas

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -28,12 +28,13 @@ jobs:
           key: ${{ runner.os }}-build-${{ matrix.python-version }}
       - name: install-reqs
         run: python -m pip install --upgrade tox virtualenv setuptools pip -r requirements-dev.txt
-      - name: run pytest (3.8 only)
-        if: matrix.python-version == "3.8"
-        run: pytest tests --cov=dataframe_api_compat --cov=tests
-      - name: run pytest (not 3.8, report coverage)
-        if: matrix.python-version != "3.8"
-        run: pytest tests --cov=dataframe_api_compat --cov=tests --cov-fail-under=100
+      - name: Run pytest
+        run: |
+          if [ "${{ matrix.python-version }}" = "3.8" ]; then
+            pytest tests --cov=dataframe_api_compat --cov=tests
+          else
+            pytest tests --cov=dataframe_api_compat --cov=tests --cov-fail-under=100
+          fi
       - name: install type-checking reqs
         run: python -m pip install 'git+https://github.com/data-apis/dataframe-api.git#egg=dataframe_api&subdirectory=spec/API_specification' mypy typing-extensions
       - name: run mypy

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -29,10 +29,10 @@ jobs:
       - name: install-reqs
         run: python -m pip install --upgrade tox virtualenv setuptools pip -r requirements-dev.txt
       - name: run pytest (3.8 only)
-        if: max.python-version == "3.8"
+        if: matrix.python-version == "3.8"
         run: pytest tests --cov=dataframe_api_compat --cov=tests
       - name: run pytest (not 3.8, report coverage)
-        if: max.python-version != "3.8"
+        if: matrix.python-version != "3.8"
         run: pytest tests --cov=dataframe_api_compat --cov=tests --cov-fail-under=100
       - name: install type-checking reqs
         run: python -m pip install 'git+https://github.com/data-apis/dataframe-api.git#egg=dataframe_api&subdirectory=spec/API_specification' mypy typing-extensions

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run pytest
         run: |
           if [ "${{ matrix.python-version }}" = "3.8" ]; then
-            pytest tests --cov=dataframe_api_compat --cov=tests
+            pytest tests --cov=dataframe_api_compat --cov=tests --cov-fail-under=50
           else
             pytest tests --cov=dataframe_api_compat --cov=tests --cov-fail-under=100
           fi

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -42,7 +42,7 @@ jobs:
   tox-all-supported:
     strategy:
       matrix:
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.8"]
         os: [windows-latest, ubuntu-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,7 +9,7 @@ jobs:
   tox:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11"]
         os: [windows-latest, ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
@@ -29,32 +29,40 @@ jobs:
       - name: install-reqs
         run: python -m pip install --upgrade tox virtualenv setuptools pip -r requirements-dev.txt
       - name: Run pytest
-        run: |
-          if ([ "${{ matrix.python-version }}" = "3.8" ] || [ "${{ matrix.python-version }}" = "3.12" ]); then
-            pytest tests --cov=dataframe_api_compat --cov=tests --cov-fail-under=50
-          else
-            pytest tests --cov=dataframe_api_compat --cov=tests --cov-fail-under=100
-          fi
+        run: pytest tests --cov=dataframe_api_compat --cov=tests --cov-fail-under=100
       - name: install type-checking reqs
-        run: |
-          if ([ "${{ matrix.python-version }}" = "3.8" ] || [ "${{ matrix.python-version }}" = "3.12" ]); then
-            echo "skipping mypy for python 3.8"
-          else
-            python -m pip install 'git+https://github.com/data-apis/dataframe-api.git#egg=dataframe_api&subdirectory=spec/API_specification' mypy typing-extensions
-          fi
+        run: python -m pip install 'git+https://github.com/data-apis/dataframe-api.git#egg=dataframe_api&subdirectory=spec/API_specification' mypy typing-extensions
       - name: run mypy
-        run: |
-          if ([ "${{ matrix.python-version }}" = "3.8" ] || [ "${{ matrix.python-version }}" = "3.12" ]); then
-            echo "skipping mypy for python 3.8"
-          else
-            mypy dataframe_api_compat tests
-          fi
+        run: mypy dataframe_api_compat tests
       - name: run polars integration tests
         run: pip uninstall pandas -y && pytest tests/integration/upstream_test.py::TestPolars && pip install -U pandas
       - name: run pandas integration tests
-        run: |
-          if ([ "${{ matrix.python-version }}" = "3.8" ] || [ "${{ matrix.python-version }}" = "3.12" ]); then
-            echo "skipping pandas for python 3.8"
-          else
-            pip uninstall polars -y && pytest tests/integration/upstream_test.py::TestPandas
-          fi
+        run: pip uninstall polars -y && pytest tests/integration/upstream_test.py::TestPandas
+
+  tox-all-supported:
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.12"]
+        os: [windows-latest, ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache multiple paths
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            $RUNNER_TOOL_CACHE/Python/*
+            ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-build-${{ matrix.python-version }}
+      - name: install-reqs
+        run: python -m pip install --upgrade tox virtualenv setuptools pip -r requirements-dev.txt
+      - name: Run pytest
+        run: pytest tests --cov=dataframe_api_compat --cov=tests --cov-fail-under=50
+      # todo: add mypy here too!
+      - name: run polars integration tests
+        run: pip uninstall pandas -y && pytest tests/integration/upstream_test.py::TestPolars && pip install -U pandas

--- a/dataframe_api_compat/polars_standard/column_object.py
+++ b/dataframe_api_compat/polars_standard/column_object.py
@@ -134,9 +134,9 @@ class Column(ColumnT):
         return self.df
 
     def get_rows(self, indices: Column) -> Column:
-        if POLARS_VERSION >= "0.19.14":
-            return self._from_expr(self.expr.gather(indices.expr))
-        return self._from_expr(self.expr.take(indices.expr))
+        if POLARS_VERSION < "0.19.14":
+            return self._from_expr(self.expr.take(indices.expr))
+        return self._from_expr(self.expr.gather(indices.expr))
 
     def slice_rows(
         self,
@@ -149,21 +149,21 @@ class Column(ColumnT):
         length = None if stop is None else stop - start
         if step is None:
             step = 1
-        if POLARS_VERSION >= "0.19.14":
-            return self._from_expr(self.expr.slice(start, length).gather_every(step))
-        return self._from_expr(self.expr.slice(start, length).take_every(step))
+        if POLARS_VERSION < "0.19.14":
+            return self._from_expr(self.expr.slice(start, length).take_every(step))
+        return self._from_expr(self.expr.slice(start, length).gather_every(step))
 
     def filter(self, mask: Column) -> Column:
         return self._from_expr(self.expr.filter(mask.expr))
 
     def get_value(self, row_number: int) -> Any:
-        if POLARS_VERSION >= "0.19.14":
+        if POLARS_VERSION < "0.19.14":
             return self._to_scalar(
-                self.expr.gather(row_number),
+                self.expr.take(row_number),
                 is_persisted=self._is_persisted,
             )
         return self._to_scalar(
-            self.expr.take(row_number),
+            self.expr.gather(row_number),
             is_persisted=self._is_persisted,
         )
 
@@ -401,24 +401,24 @@ class Column(ColumnT):
         return self._from_expr(self.expr.fill_null(value))
 
     def cumulative_sum(self, *, skip_nulls: bool | Scalar = True) -> Column:
-        if POLARS_VERSION >= "0.19.14":
-            return self._from_expr(self.expr.cum_sum())
-        return self._from_expr(self.expr.cumsum())
+        if POLARS_VERSION < "0.19.14":
+            return self._from_expr(self.expr.cumsum())
+        return self._from_expr(self.expr.cum_sum())
 
     def cumulative_prod(self, *, skip_nulls: bool | Scalar = True) -> Column:
-        if POLARS_VERSION >= "0.19.14":
-            return self._from_expr(self.expr.cum_prod())
-        return self._from_expr(self.expr.cumprod())
+        if POLARS_VERSION < "0.19.14":
+            return self._from_expr(self.expr.cumprod())
+        return self._from_expr(self.expr.cum_prod())
 
     def cumulative_max(self, *, skip_nulls: bool | Scalar = True) -> Column:
-        if POLARS_VERSION >= "0.19.14":
-            return self._from_expr(self.expr.cum_max())
-        return self._from_expr(self.expr.cummax())
+        if POLARS_VERSION < "0.19.14":
+            return self._from_expr(self.expr.cummax())
+        return self._from_expr(self.expr.cum_max())
 
     def cumulative_min(self, *, skip_nulls: bool | Scalar = True) -> Column:
-        if POLARS_VERSION >= "0.19.14":
-            return self._from_expr(self.expr.cum_min())
-        return self._from_expr(self.expr.cummin())
+        if POLARS_VERSION < "0.19.14":
+            return self._from_expr(self.expr.cummin())
+        return self._from_expr(self.expr.cum_min())
 
     def rename(self, name: str | Scalar) -> Column:
         _name = self._validate_comparand(name)

--- a/dataframe_api_compat/polars_standard/dataframe_object.py
+++ b/dataframe_api_compat/polars_standard/dataframe_object.py
@@ -146,12 +146,12 @@ class DataFrame(DataFrameT):
 
     def get_rows(self, indices: Column) -> DataFrame:  # type: ignore[override]
         self._validate_other(indices)
-        if POLARS_VERSION >= "0.19.14":
+        if POLARS_VERSION < "0.19.14":
             return self._from_dataframe(
-                self.dataframe.select(pl.all().gather(indices.expr)),
+                self.dataframe.select(pl.all().take(indices.expr)),
             )
         return self._from_dataframe(
-            self.dataframe.select(pl.all().take(indices.expr)),
+            self.dataframe.select(pl.all().gather(indices.expr)),
         )
 
     def slice_rows(

--- a/dataframe_api_compat/polars_standard/dataframe_object.py
+++ b/dataframe_api_compat/polars_standard/dataframe_object.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
 else:
     DataFrameT = object
 
+POLARS_VERSION = pl.__version__
+
 
 def _is_integer_dtype(dtype: Any) -> bool:
     return any(  # pragma: no cover
@@ -144,6 +146,10 @@ class DataFrame(DataFrameT):
 
     def get_rows(self, indices: Column) -> DataFrame:  # type: ignore[override]
         self._validate_other(indices)
+        if POLARS_VERSION >= "0.19.14":
+            return self._from_dataframe(
+                self.dataframe.select(pl.all().gather(indices.expr)),
+            )
         return self._from_dataframe(
             self.dataframe.select(pl.all().take(indices.expr)),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,5 +84,5 @@ plugins = ["covdefaults"]
 [tool.coverage.report]
 exclude_also = [
   "if POLARS_VERSION < ",
-  "if sys.version_info() < ",
+  "if sys.version_info() <",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,3 +80,9 @@ xfail_strict = true
 
 [tool.coverage.run]
 plugins = ["covdefaults"]
+
+[tool.coverage.report]
+exclude_also = [
+  "if POLARS_VERSION < ",
+  "if sys.version_info() < ",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Implementation of the DataFrame Standard for pandas and Polars"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
@@ -24,7 +24,7 @@ classifiers = [
 [tool.ruff]
 line-length = 90
 fix = true
-target-version = "py39"
+target-version = "py38"
 
 select = [
 #   "E", # pycodestyle

--- a/tests/column/name_test.py
+++ b/tests/column/name_test.py
@@ -15,7 +15,7 @@ def test_name(library: str) -> None:
 
 
 @pytest.mark.skipif(
-    sys.version_info <= (3, 8),
+    sys.version_info < (3, 9),
     reason="pandas doesn't support 3.8",
 )
 def test_invalid_name_pandas() -> None:

--- a/tests/column/name_test.py
+++ b/tests/column/name_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 import pandas as pd
 import pytest
 
@@ -12,6 +14,10 @@ def test_name(library: str) -> None:
     assert name == "a"
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="pandas doesn't support 3.8",
+)
 def test_invalid_name_pandas() -> None:
     with pytest.raises(ValueError):
         pd.Series([1, 2, 3], name=0).__column_consortium_standard__()

--- a/tests/column/name_test.py
+++ b/tests/column/name_test.py
@@ -15,7 +15,7 @@ def test_name(library: str) -> None:
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 9),
+    sys.version_info < (3, 9) or sys.version_info >= (3, 12),
     reason="pandas doesn't support 3.8",
 )
 def test_invalid_name_pandas() -> None:

--- a/tests/column/name_test.py
+++ b/tests/column/name_test.py
@@ -15,7 +15,7 @@ def test_name(library: str) -> None:
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 8),
+    sys.version_info <= (3, 8),
     reason="pandas doesn't support 3.8",
 )
 def test_invalid_name_pandas() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
+import sys
 from typing import Any
+
+LIBRARIES = {
+    (3, 8): ["polars-lazy"],
+    (3, 9): ["pandas-numpy", "pandas-nullable", "polars-lazy"],
+    (3, 10): ["pandas-numpy", "pandas-nullable", "polars-lazy"],
+    (3, 11): ["pandas-numpy", "pandas-nullable", "polars-lazy"],
+    (3, 12): ["polars-lazy"],
+}
 
 
 def pytest_generate_tests(metafunc: Any) -> None:
     if "library" in metafunc.fixturenames:
         metafunc.parametrize(
             "library",
-            [
-                "pandas-numpy",
-                "pandas-nullable",
-                "polars-lazy",
-            ],
+            LIBRARIES[sys.version_info[:2]],
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ LIBRARIES = {
     (3, 9): ["pandas-numpy", "pandas-nullable", "polars-lazy"],
     (3, 10): ["pandas-numpy", "pandas-nullable", "polars-lazy"],
     (3, 11): ["pandas-numpy", "pandas-nullable", "polars-lazy"],
-    (3, 12): ["pandas-numpy", "pandas-nullable", "polars-lazy"],
+    (3, 12): ["polars-lazy"],
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ LIBRARIES = {
     (3, 9): ["pandas-numpy", "pandas-nullable", "polars-lazy"],
     (3, 10): ["pandas-numpy", "pandas-nullable", "polars-lazy"],
     (3, 11): ["pandas-numpy", "pandas-nullable", "polars-lazy"],
-    (3, 12): ["polars-lazy"],
+    (3, 12): ["pandas-numpy", "pandas-nullable", "polars-lazy"],
 }
 
 

--- a/tests/integration/scale_column_test.py
+++ b/tests/integration/scale_column_test.py
@@ -9,7 +9,7 @@ from polars.testing import assert_series_equal
 
 
 @pytest.mark.skipif(
-    sys.version_info <= (3, 8),
+    sys.version_info < (3, 9),
     reason="pandas doesn't support 3.8",
 )
 def test_scale_column_pandas() -> None:

--- a/tests/integration/scale_column_test.py
+++ b/tests/integration/scale_column_test.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+import sys
+
 import pandas as pd
 import polars as pl
+import pytest
 from polars.testing import assert_series_equal
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="pandas doesn't support 3.8",
+)
 def test_scale_column_pandas() -> None:
     s = pd.Series([1, 2, 3], name="a")
     ser = s.__column_consortium_standard__()

--- a/tests/integration/scale_column_test.py
+++ b/tests/integration/scale_column_test.py
@@ -9,7 +9,7 @@ from polars.testing import assert_series_equal
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 9),
+    sys.version_info < (3, 9) or sys.version_info >= (3, 12),
     reason="pandas doesn't support 3.8",
 )
 def test_scale_column_pandas() -> None:

--- a/tests/integration/scale_column_test.py
+++ b/tests/integration/scale_column_test.py
@@ -9,7 +9,7 @@ from polars.testing import assert_series_equal
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 8),
+    sys.version_info <= (3, 8),
     reason="pandas doesn't support 3.8",
 )
 def test_scale_column_pandas() -> None:

--- a/tests/integration/upstream_test.py
+++ b/tests/integration/upstream_test.py
@@ -28,7 +28,7 @@ class TestPolars:
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 9),
+    sys.version_info < (3, 9) or sys.version_info >= (3, 12),
     reason="pandas doesn't support 3.8",
 )
 class TestPandas:

--- a/tests/integration/upstream_test.py
+++ b/tests/integration/upstream_test.py
@@ -28,7 +28,7 @@ class TestPolars:
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 8),
+    sys.version_info <= (3, 8),
     reason="pandas doesn't support 3.8",
 )
 class TestPandas:

--- a/tests/integration/upstream_test.py
+++ b/tests/integration/upstream_test.py
@@ -1,3 +1,8 @@
+import sys
+
+import pytest
+
+
 class TestPolars:
     def test_dataframe(self) -> None:
         import polars as pl
@@ -22,6 +27,10 @@ class TestPolars:
         assert col.name == "a"
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="pandas doesn't support 3.8",
+)
 class TestPandas:
     def test_pandas(self) -> None:
         """

--- a/tests/integration/upstream_test.py
+++ b/tests/integration/upstream_test.py
@@ -28,7 +28,7 @@ class TestPolars:
 
 
 @pytest.mark.skipif(
-    sys.version_info <= (3, 8),
+    sys.version_info < (3, 9),
     reason="pandas doesn't support 3.8",
 )
 class TestPandas:

--- a/tests/namespace/convert_to_standard_column_test.py
+++ b/tests/namespace/convert_to_standard_column_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 import pandas as pd
 import polars as pl
 
@@ -9,7 +11,8 @@ def test_convert_to_std_column() -> None:
     assert float(s.mean().persist()) == 2
     s = pl.Series("bob", [1, 2, 3]).__column_consortium_standard__()
     assert float(s.mean().persist()) == 2
-    s = pd.Series([1, 2, 3]).__column_consortium_standard__()
-    assert float(s.mean().persist()) == 2
-    s = pd.Series([1, 2, 3], name="alice").__column_consortium_standard__()
-    assert float(s.mean().persist()) == 2
+    if sys.version_info >= (3, 9):
+        s = pd.Series([1, 2, 3]).__column_consortium_standard__()
+        assert float(s.mean().persist()) == 2
+        s = pd.Series([1, 2, 3], name="alice").__column_consortium_standard__()
+        assert float(s.mean().persist()) == 2

--- a/tests/namespace/convert_to_standard_column_test.py
+++ b/tests/namespace/convert_to_standard_column_test.py
@@ -11,8 +11,10 @@ def test_convert_to_std_column() -> None:
     assert float(s.mean().persist()) == 2
     s = pl.Series("bob", [1, 2, 3]).__column_consortium_standard__()
     assert float(s.mean().persist()) == 2
-    if sys.version_info >= (3, 9):
-        s = pd.Series([1, 2, 3]).__column_consortium_standard__()
-        assert float(s.mean().persist()) == 2
-        s = pd.Series([1, 2, 3], name="alice").__column_consortium_standard__()
-        assert float(s.mean().persist()) == 2
+    if sys.version_info < (3, 8):
+        # pandas doesn't support 3.8
+        return
+    s = pd.Series([1, 2, 3]).__column_consortium_standard__()
+    assert float(s.mean().persist()) == 2
+    s = pd.Series([1, 2, 3], name="alice").__column_consortium_standard__()
+    assert float(s.mean().persist()) == 2

--- a/tests/namespace/convert_to_standard_column_test.py
+++ b/tests/namespace/convert_to_standard_column_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 import pandas as pd
 import polars as pl
 
@@ -9,6 +11,9 @@ def test_convert_to_std_column() -> None:
     assert float(s.mean().persist()) == 2
     s = pl.Series("bob", [1, 2, 3]).__column_consortium_standard__()
     assert float(s.mean().persist()) == 2
+    if sys.version_info < (3, 9):
+        # pandas doesn't support 3.8
+        return
     s = pd.Series([1, 2, 3]).__column_consortium_standard__()
     assert float(s.mean().persist()) == 2
     s = pd.Series([1, 2, 3], name="alice").__column_consortium_standard__()

--- a/tests/namespace/convert_to_standard_column_test.py
+++ b/tests/namespace/convert_to_standard_column_test.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import sys
-
 import pandas as pd
 import polars as pl
 
@@ -11,9 +9,6 @@ def test_convert_to_std_column() -> None:
     assert float(s.mean().persist()) == 2
     s = pl.Series("bob", [1, 2, 3]).__column_consortium_standard__()
     assert float(s.mean().persist()) == 2
-    if sys.version_info < (3, 8):
-        # pandas doesn't support 3.8
-        return
     s = pd.Series([1, 2, 3]).__column_consortium_standard__()
     assert float(s.mean().persist()) == 2
     s = pd.Series([1, 2, 3], name="alice").__column_consortium_standard__()

--- a/tests/namespace/convert_to_standard_column_test.py
+++ b/tests/namespace/convert_to_standard_column_test.py
@@ -11,7 +11,7 @@ def test_convert_to_std_column() -> None:
     assert float(s.mean().persist()) == 2
     s = pl.Series("bob", [1, 2, 3]).__column_consortium_standard__()
     assert float(s.mean().persist()) == 2
-    if sys.version_info < (3, 9):
+    if sys.version_info < (3, 9) or sys.version_info >= (3, 12):
         # pandas doesn't support 3.8
         return
     s = pd.Series([1, 2, 3]).__column_consortium_standard__()


### PR DESCRIPTION
things break trying to run pandas on 3.12

need to rewrite the tests so that they don't depend on pandas at all