### PR TITLE
Remove unnecessary `convert_dataframe_to_pandas_numpy` call after `interchange_to_pandas` call

### DIFF
--- a/tests/column/col_sorted_indices_test.py
+++ b/tests/column/col_sorted_indices_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pandas as pd
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_6
 from tests.utils import interchange_to_pandas
 
@@ -14,7 +13,6 @@ def test_expression_sorted_indices_ascending(library: str) -> None:
     sorted_indices = col("b").sorted_indices()
     result = df.take(sorted_indices)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame(
         {
             "a": [2, 2, 1, 1, 1],
@@ -31,7 +29,6 @@ def test_expression_sorted_indices_descending(library: str) -> None:
     sorted_indices = col("b").sorted_indices(ascending=False)
     result = df.take(sorted_indices)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame(
         {
             "a": [1, 1, 1, 2, 2],
@@ -46,7 +43,6 @@ def test_column_sorted_indices_ascending(library: str) -> None:
     sorted_indices = df.col("b").sorted_indices()
     result = df.take(sorted_indices)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame(
         {
             "a": [2, 2, 1, 1, 1],
@@ -61,7 +57,6 @@ def test_column_sorted_indices_descending(library: str) -> None:
     sorted_indices = df.col("b").sorted_indices(ascending=False)
     result = df.take(sorted_indices)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame(
         {
             "a": [1, 1, 1, 2, 2],

--- a/tests/column/pow_test.py
+++ b/tests/column/pow_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pandas as pd
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_1
 from tests.utils import interchange_to_pandas
 
@@ -17,7 +16,6 @@ def test_float_powers_column(library: str) -> None:
     expected = pd.DataFrame(
         {"a": [1, 2, 3], "b": [4, 5, 6], "result": [1.0, 32.0, 729.0]},
     )
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     pd.testing.assert_frame_equal(result_pd, expected)
 
 
@@ -29,7 +27,6 @@ def test_float_powers_scalar_column(library: str) -> None:
     result = df.assign(ser.__pow__(other).rename("result"))
     result_pd = interchange_to_pandas(result)
     expected = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "result": [1.0, 2.0, 3.0]})
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     pd.testing.assert_frame_equal(result_pd, expected)
 
 
@@ -41,7 +38,6 @@ def test_int_powers_column(library: str) -> None:
     result = df.assign(ser.__pow__(other).rename("result"))
     result_pd = interchange_to_pandas(result)
     expected = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "result": [1, 32, 729]})
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     if library in ("polars", "polars-lazy"):
         result_pd = result_pd.astype("int64")
     pd.testing.assert_frame_equal(result_pd, expected)
@@ -55,7 +51,6 @@ def test_int_powers_scalar_column(library: str) -> None:
     result = df.assign(ser.__pow__(other).rename("result"))
     result_pd = interchange_to_pandas(result)
     expected = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "result": [1, 2, 3]})
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     if library in ("polars", "polars-lazy"):
         result_pd = result_pd.astype("int64")
     pd.testing.assert_frame_equal(result_pd, expected)

--- a/tests/column/sort_test.py
+++ b/tests/column/sort_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pandas as pd
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_6
 from tests.utils import interchange_to_pandas
 
@@ -13,7 +12,6 @@ def test_expression_sort_ascending(library: str) -> None:
     s_sorted = df.col("b").sort().rename("c")
     result = df.assign(s_sorted)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame(
         {
             "a": [1, 1, 1, 2, 2],
@@ -30,7 +28,6 @@ def test_expression_sort_descending(library: str) -> None:
     s_sorted = df.col("b").sort(ascending=False).rename("c")
     result = df.assign(s_sorted)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame(
         {
             "a": [1, 1, 1, 2, 2],
@@ -46,7 +43,6 @@ def test_column_sort_ascending(library: str) -> None:
     s_sorted = df.col("b").sort().rename("c")
     result = df.assign(s_sorted)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame(
         {
             "a": [1, 1, 1, 2, 2],
@@ -62,7 +58,6 @@ def test_column_sort_descending(library: str) -> None:
     s_sorted = df.col("b").sort(ascending=False).rename("c")
     result = df.assign(s_sorted)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame(
         {
             "a": [1, 1, 1, 2, 2],

--- a/tests/dataframe/all_rowwise_test.py
+++ b/tests/dataframe/all_rowwise_test.py
@@ -4,7 +4,6 @@ import pandas as pd
 import pytest
 
 from tests.utils import bool_dataframe_1
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import interchange_to_pandas
 
 
@@ -14,7 +13,6 @@ def test_all_horizontal(library: str) -> None:
     mask = namespace.all_horizontal(*[df.col(col_name) for col_name in df.column_names])
     result = df.filter(mask)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [True, True], "b": [True, True]})
     pd.testing.assert_frame_equal(result_pd, expected)
 

--- a/tests/dataframe/and_test.py
+++ b/tests/dataframe/and_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pandas as pd
 
 from tests.utils import bool_dataframe_1
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import interchange_to_pandas
 
 
@@ -12,7 +11,6 @@ def test_and_with_scalar(library: str) -> None:
     other = True
     result = df & other
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [True, True, False], "b": [True, True, True]})
     pd.testing.assert_frame_equal(result_pd, expected)
 
@@ -22,6 +20,5 @@ def test_rand_with_scalar(library: str) -> None:
     other = True
     result = other & df
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [True, True, False], "b": [True, True, True]})
     pd.testing.assert_frame_equal(result_pd, expected)

--- a/tests/dataframe/any_all_test.py
+++ b/tests/dataframe/any_all_test.py
@@ -5,7 +5,6 @@ import pytest
 
 from tests.utils import bool_dataframe_1
 from tests.utils import bool_dataframe_3
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import interchange_to_pandas
 
 
@@ -24,7 +23,6 @@ def test_reductions(
     df = bool_dataframe_1(library)
     result = getattr(df, reduction)()
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame(expected_data)
     pd.testing.assert_frame_equal(result_pd, expected)
 
@@ -33,7 +31,6 @@ def test_any(library: str) -> None:
     df = bool_dataframe_3(library)
     result = df.any()
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [False], "b": [True], "c": [True]})
     pd.testing.assert_frame_equal(result_pd, expected)
 
@@ -42,6 +39,5 @@ def test_all(library: str) -> None:
     df = bool_dataframe_3(library)
     result = df.all()
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [False], "b": [False], "c": [True]})
     pd.testing.assert_frame_equal(result_pd, expected)

--- a/tests/dataframe/any_rowwise_test.py
+++ b/tests/dataframe/any_rowwise_test.py
@@ -4,7 +4,6 @@ import pandas as pd
 import pytest
 
 from tests.utils import bool_dataframe_1
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import interchange_to_pandas
 
 
@@ -14,7 +13,6 @@ def test_any_horizontal(library: str) -> None:
     mask = namespace.any_horizontal(*[df.col(col_name) for col_name in df.column_names])
     result = df.filter(mask)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [True, True, False], "b": [True, True, True]})
     pd.testing.assert_frame_equal(result_pd, expected)
 

--- a/tests/dataframe/assign_test.py
+++ b/tests/dataframe/assign_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_1
 from tests.utils import interchange_to_pandas
 
@@ -14,12 +13,10 @@ def test_insert_columns(library: str) -> None:
     new_col = (df.col("b") + 3).rename("result")
     result = df.assign(new_col.rename("c"))
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
     pd.testing.assert_frame_equal(result_pd, expected)
     # check original df didn't change
     df_pd = interchange_to_pandas(df)
-    df_pd = convert_dataframe_to_pandas_numpy(df_pd)
     expected = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     pd.testing.assert_frame_equal(df_pd, expected)
 
@@ -30,14 +27,12 @@ def test_insert_multiple_columns(library: str) -> None:
     new_col = (df.col("b") + 3).rename("result")
     result = df.assign(new_col.rename("c"), new_col.rename("d"))
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame(
         {"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9], "d": [7, 8, 9]},
     )
     pd.testing.assert_frame_equal(result_pd, expected)
     # check original df didn't change
     df_pd = interchange_to_pandas(df)
-    df_pd = convert_dataframe_to_pandas_numpy(df_pd)
     expected = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     pd.testing.assert_frame_equal(df_pd, expected)
 
@@ -55,13 +50,11 @@ def test_insert_eager_columns(library: str) -> None:
     new_col = (df.col("b") + 3).rename("result")
     result = df.assign(new_col.rename("c"), new_col.rename("d"))
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame(
         {"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9], "d": [7, 8, 9]},
     )
     pd.testing.assert_frame_equal(result_pd, expected)
     # check original df didn't change
     df_pd = interchange_to_pandas(df)
-    df_pd = convert_dataframe_to_pandas_numpy(df_pd)
     expected = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     pd.testing.assert_frame_equal(df_pd, expected)

--- a/tests/dataframe/comparisons_test.py
+++ b/tests/dataframe/comparisons_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_1
 from tests.utils import interchange_to_pandas
 
@@ -35,7 +34,6 @@ def test_comparisons_with_scalar(
     other = 2
     result = getattr(df, comparison)(other)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame(expected_data)
     pd.testing.assert_frame_equal(result_pd, expected)
 
@@ -57,6 +55,5 @@ def test_rcomparisons_with_scalar(
     other = 2
     result = getattr(df, comparison)(other)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame(expected_data)
     pd.testing.assert_frame_equal(result_pd, expected)

--- a/tests/dataframe/divmod_test.py
+++ b/tests/dataframe/divmod_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pandas as pd
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_1
 from tests.utils import interchange_to_pandas
 
@@ -15,7 +14,5 @@ def test_divmod_with_scalar(library: str) -> None:
     result_remainder_pd = interchange_to_pandas(result_remainder)
     expected_quotient = pd.DataFrame({"a": [0, 1, 1], "b": [2, 2, 3]})
     expected_remainder = pd.DataFrame({"a": [1, 0, 1], "b": [0, 1, 0]})
-    result_quotient_pd = convert_dataframe_to_pandas_numpy(result_quotient_pd)
-    result_remainder_pd = convert_dataframe_to_pandas_numpy(result_remainder_pd)
     pd.testing.assert_frame_equal(result_quotient_pd, expected_quotient)
     pd.testing.assert_frame_equal(result_remainder_pd, expected_remainder)

--- a/tests/dataframe/drop_column_test.py
+++ b/tests/dataframe/drop_column_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pandas as pd
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_1
 from tests.utils import interchange_to_pandas
 
@@ -11,6 +10,5 @@ def test_drop_column(library: str) -> None:
     df = integer_dataframe_1(library)
     result = df.drop("a")
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"b": [4, 5, 6]})
     pd.testing.assert_frame_equal(result_pd, expected)

--- a/tests/dataframe/get_column_by_name_test.py
+++ b/tests/dataframe/get_column_by_name_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pandas as pd
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_1
 from tests.utils import interchange_to_pandas
 
@@ -14,6 +13,5 @@ def test_get_column(library: str) -> None:
     result = df.assign(col("a").rename("_tmp")).drop("a").rename({"_tmp": "a"})
     df.__dataframe_namespace__()
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})[["b", "a"]]
     pd.testing.assert_frame_equal(result_pd, expected)

--- a/tests/dataframe/get_rows_by_mask_test.py
+++ b/tests/dataframe/get_rows_by_mask_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pandas as pd
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_1
 from tests.utils import interchange_to_pandas
 
@@ -13,6 +12,5 @@ def test_filter(library: str) -> None:
     mask = df.col("a") % 2 == 1
     result = df.filter(mask)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [1, 3], "b": [4, 6]})
     pd.testing.assert_frame_equal(result_pd, expected)

--- a/tests/dataframe/get_rows_test.py
+++ b/tests/dataframe/get_rows_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pandas as pd
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_1
 from tests.utils import interchange_to_pandas
 
@@ -14,6 +13,5 @@ def test_take(library: str) -> None:
     df.__dataframe_namespace__()
     result = df.take(df.col("result"))
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [3, 2, 1], "b": [6, 5, 4], "result": [0, 1, 2]})
     pd.testing.assert_frame_equal(result_pd, expected)

--- a/tests/dataframe/invert_test.py
+++ b/tests/dataframe/invert_test.py
@@ -4,7 +4,6 @@ import pandas as pd
 import pytest
 
 from tests.utils import bool_dataframe_1
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_1
 from tests.utils import interchange_to_pandas
 
@@ -13,7 +12,6 @@ def test_invert(library: str) -> None:
     df = bool_dataframe_1(library)
     result = ~df
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [False, False, True], "b": [False, False, False]})
     pd.testing.assert_frame_equal(result_pd, expected)
 

--- a/tests/dataframe/or_test.py
+++ b/tests/dataframe/or_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pandas as pd
 
 from tests.utils import bool_dataframe_1
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import interchange_to_pandas
 
 
@@ -12,7 +11,6 @@ def test_or_with_scalar(library: str) -> None:
     other = True
     result = df | other
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [True, True, True], "b": [True, True, True]})
     pd.testing.assert_frame_equal(result_pd, expected)
 
@@ -22,6 +20,5 @@ def test_ror_with_scalar(library: str) -> None:
     other = True
     result = other | df
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [True, True, True], "b": [True, True, True]})
     pd.testing.assert_frame_equal(result_pd, expected)

--- a/tests/dataframe/pow_test.py
+++ b/tests/dataframe/pow_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pandas as pd
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_1
 from tests.utils import interchange_to_pandas
 
@@ -11,9 +10,8 @@ def test_float_scalar_powers(library: str) -> None:
     df = integer_dataframe_1(library)
     other = 1.0
     result = df.__pow__(other)
-    result_pd = interchange_to_pandas(result)
-    expected = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd).astype(
+    result_pd = interchange_to_pandas(result).astype(
         {"a": "int64", "b": "int64"},
     )
+    expected = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     pd.testing.assert_frame_equal(result_pd, expected)

--- a/tests/dataframe/reductions_test.py
+++ b/tests/dataframe/reductions_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_1
 from tests.utils import interchange_to_pandas
 
@@ -29,5 +28,4 @@ def test_dataframe_reductions(
     df = integer_dataframe_1(library)
     result = getattr(df, reduction)()
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     pd.testing.assert_frame_equal(result_pd, expected)

--- a/tests/dataframe/rename_columns_test.py
+++ b/tests/dataframe/rename_columns_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_1
 from tests.utils import interchange_to_pandas
 
@@ -12,7 +11,6 @@ def test_rename(library: str) -> None:
     df = integer_dataframe_1(library)
     result = df.rename({"a": "c", "b": "e"})
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"c": [1, 2, 3], "e": [4, 5, 6]})
     pd.testing.assert_frame_equal(result_pd, expected)
 

--- a/tests/dataframe/select_test.py
+++ b/tests/dataframe/select_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_1
 from tests.utils import interchange_to_pandas
 
@@ -12,7 +11,6 @@ def test_select(library: str) -> None:
     df = integer_dataframe_1(library)
     result = df.select("b")
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"b": [4, 5, 6]})
     pd.testing.assert_frame_equal(result_pd, expected)
 
@@ -21,7 +19,6 @@ def test_select_list_of_str(library: str) -> None:
     df = integer_dataframe_1(library)
     result = df.select("a", "b")
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     pd.testing.assert_frame_equal(result_pd, expected)
 

--- a/tests/dataframe/slice_rows_test.py
+++ b/tests/dataframe/slice_rows_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_3
 from tests.utils import interchange_to_pandas
 
@@ -27,5 +26,4 @@ def test_slice_rows(
     df = integer_dataframe_3(library)
     result = df.slice_rows(start, stop, step)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     pd.testing.assert_frame_equal(result_pd, expected)

--- a/tests/dataframe/sort_test.py
+++ b/tests/dataframe/sort_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_5
 from tests.utils import interchange_to_pandas
 
@@ -13,7 +12,6 @@ def test_sort(library: str, keys: list[str]) -> None:
     df = integer_dataframe_5(library, api_version="2023.09-beta")
     result = df.sort(*keys)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [1, 1], "b": [3, 4]})
     pd.testing.assert_frame_equal(result_pd, expected)
 
@@ -26,6 +24,5 @@ def test_sort_descending(
     df = integer_dataframe_5(library, api_version="2023.09-beta")
     result = df.sort(*keys, ascending=False)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [1, 1], "b": [4, 3]})
     pd.testing.assert_frame_equal(result_pd, expected)

--- a/tests/dataframe/update_test.py
+++ b/tests/dataframe/update_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pandas as pd
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_1
 from tests.utils import interchange_to_pandas
 
@@ -13,12 +12,10 @@ def test_update_column(library: str) -> None:
     new_col = df.col("b") + 3
     result = df.assign(new_col)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [1, 2, 3], "b": [7, 8, 9]})
     pd.testing.assert_frame_equal(result_pd, expected)
     # check original df didn't change
     df_pd = interchange_to_pandas(df)
-    df_pd = convert_dataframe_to_pandas_numpy(df_pd)
     expected = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     pd.testing.assert_frame_equal(df_pd, expected)
 
@@ -30,11 +27,9 @@ def test_update_columns(library: str) -> None:
     new_col_b = df.col("b") + 3
     result = df.assign(new_col_a, new_col_b)
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [2, 3, 4], "b": [7, 8, 9]})
     pd.testing.assert_frame_equal(result_pd, expected)
     # check original df didn't change
     df_pd = interchange_to_pandas(df)
-    df_pd = convert_dataframe_to_pandas_numpy(df_pd)
     expected = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     pd.testing.assert_frame_equal(df_pd, expected)

--- a/tests/groupby/groupby_any_all_test.py
+++ b/tests/groupby/groupby_any_all_test.py
@@ -5,7 +5,6 @@ import pytest
 from polars.exceptions import SchemaError
 
 from tests.utils import bool_dataframe_2
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_4
 from tests.utils import interchange_to_pandas
 
@@ -29,7 +28,6 @@ def test_groupby_boolean(
     # need to sort
     result = result.sort("key")
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     if library == "pandas-nullable" and tuple(
         int(v) for v in pd.__version__.split(".")
     ) < (

--- a/tests/groupby/numeric_test.py
+++ b/tests/groupby/numeric_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_4
 from tests.utils import interchange_to_pandas
 
@@ -35,7 +34,6 @@ def test_group_by_numeric(
     result = getattr(df.group_by("key"), aggregation)()
     result = result.sort("key")
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"key": [1, 2], "b": expected_b, "c": expected_c})
     if library == "pandas-nullable" and tuple(
         int(v) for v in pd.__version__.split(".")

--- a/tests/groupby/size_test.py
+++ b/tests/groupby/size_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pandas as pd
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_4
 from tests.utils import interchange_to_pandas
 
@@ -15,5 +14,4 @@ def test_group_by_size(library: str) -> None:
     expected = pd.DataFrame({"key": [1, 2], "size": [2, 2]})
     # TODO polars returns uint32. what do we standardise to?
     result_pd["size"] = result_pd["size"].astype("int64")
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     pd.testing.assert_frame_equal(result_pd, expected)

--- a/tests/integration/persistedness_test.py
+++ b/tests/integration/persistedness_test.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import pytest
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_1
 from tests.utils import integer_dataframe_2
 from tests.utils import interchange_to_pandas
@@ -62,7 +61,7 @@ def test_cross_df_propagation(library: str) -> None:
     df1 = (df1 + 1).persist()
     df2 = df2.rename({"b": "c"}).persist()
     result = df1.join(df2, how="left", left_on="a", right_on="a")
-    result_pd = convert_dataframe_to_pandas_numpy(interchange_to_pandas(result))
+    result_pd = interchange_to_pandas(result)
     expected = pd.DataFrame(
         {
             "a": [2, 3, 4],

--- a/tests/namespace/concat_test.py
+++ b/tests/namespace/concat_test.py
@@ -4,7 +4,6 @@ import pandas as pd
 import polars as pl
 import pytest
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_1
 from tests.utils import integer_dataframe_2
 from tests.utils import integer_dataframe_4
@@ -17,7 +16,6 @@ def test_concat(library: str) -> None:
     namespace = df1.__dataframe_namespace__()
     result = namespace.concat([df1, df2])
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [1, 2, 3, 1, 2, 4], "b": [4, 5, 6, 4, 2, 6]})
     pd.testing.assert_frame_equal(result_pd, expected)
 

--- a/tests/namespace/dataframe_from_2d_array_test.py
+++ b/tests/namespace/dataframe_from_2d_array_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_1
 from tests.utils import interchange_to_pandas
 
@@ -18,6 +17,5 @@ def test_dataframe_from_2d_array(library: str) -> None:
     )
     # TODO: consistent return type, for windows compat?
     result_pd = interchange_to_pandas(result).astype("int64")
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     pd.testing.assert_frame_equal(result_pd, expected)

--- a/tests/namespace/sorted_indices_test.py
+++ b/tests/namespace/sorted_indices_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pandas as pd
 
-from tests.utils import convert_dataframe_to_pandas_numpy
 from tests.utils import integer_dataframe_6
 from tests.utils import interchange_to_pandas
 
@@ -12,7 +11,6 @@ def test_column_sorted_indices_ascending(library: str) -> None:
     sorted_indices = df.col("b").sorted_indices()
     result = df.assign(sorted_indices.rename("result"))
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected_1 = pd.DataFrame(
         {
             "a": [1, 1, 1, 2, 2],
@@ -41,7 +39,6 @@ def test_column_sorted_indices_descending(library: str) -> None:
     sorted_indices = df.col("b").sorted_indices(ascending=False)
     result = df.assign(sorted_indices.rename("result"))
     result_pd = interchange_to_pandas(result)
-    result_pd = convert_dataframe_to_pandas_numpy(result_pd)
     expected_1 = pd.DataFrame(
         {
             "a": [1, 1, 1, 2, 2],


### PR DESCRIPTION
`interchange_to_pandas` uses `convert_dataframe_to_pandas_numpy` internally in all cases.