### PR TITLE
Bump version 0.2.7

### DIFF
--- a/dataframe_api_compat/__init__.py
+++ b/dataframe_api_compat/__init__.py
@@ -16,4 +16,4 @@ def __getattr__(name: str) -> ModuleType:
     raise AttributeError(msg)
 
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,6 +11,6 @@ Then, if you start the Python REPL and see the following:
 ```python
 >>> import dataframe_api_compat
 >>> dataframe_api_compat.__version__
-'0.2.6'
+'0.2.7'
 ```
 then installation worked correctly!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dataframe_api_compat"
-version = "0.2.6"
+version = "0.2.7"
 authors = [
   { name="Marco Gorelli", email="33491632+MarcoGorelli@users.noreply.github.com" },
 ]


### PR DESCRIPTION
Looks like this is enough for a new tag (according to https://github.com/data-apis/dataframe-api-compat/commit/b70b8e968fa3e637c1efb01a4a27d243ab944605).